### PR TITLE
Aggregate monthly trend and color-code sentiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ app_file: app.py
 pinned: true
 license: mit
 ---
+
+This Streamlit app visualizes sentiment analysis for Clarín headlines.
+It now shows a monthly average sentiment trend and a histogram where
+positive, negative and neutral scores are highlighted with different
+colors for easier interpretation.


### PR DESCRIPTION
## Summary
- Smooth sentiment over time by resampling to monthly averages
- Highlight positive, negative, and neutral values with distinct colors in histogram and data table
- Document new visual cues in README

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b774c7dbd08323b2b47fedc7efae78