### PR TITLE
Expand dashboard with section and extremes analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,12 @@ app_file: app.py
 pinned: true
 license: mit
 ---
+
+This Streamlit app visualizes sentiment analysis for Clarín headlines.
+It includes:
+
+- A monthly average sentiment trend line.
+- A score distribution histogram with color cues for positive, negative and neutral values.
+- A bar chart of average sentiment by newspaper section.
+- Tables highlighting the most positive and most negative headlines.
+- A color-coded table of recent headlines with an option to download the filtered data.


### PR DESCRIPTION
## Summary
- Visualize average sentiment by section with a new bar chart
- Display top positive and negative headlines in dedicated tables
- Document the new analytics features in the README

## Testing
- `pytest -q`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b774c7dbd08323b2b47fedc7efae78