### PR TITLE
Expand dashboard with section and headline analytics

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -1,0 +1,24 @@
+import pandas as pd
+
+
+def section_avg_sentiment(df: pd.DataFrame) -> pd.DataFrame:
+    """Return average sentiment score by section."""
+    if "section" not in df.columns:
+        return pd.DataFrame(columns=["section", "avg_sentiment"])
+    return (
+        df.groupby("section")["sentiment_score"]
+        .mean()
+        .reset_index(name="avg_sentiment")
+        .sort_values("avg_sentiment", ascending=False)
+    )
+
+
+def section_label_counts(df: pd.DataFrame) -> pd.DataFrame:
+    """Return count of sentiment labels per section."""
+    if "section" not in df.columns or "sentiment_label" not in df.columns:
+        return pd.DataFrame(columns=["section", "sentiment_label", "count"])
+    return (
+        df.groupby(["section", "sentiment_label"])
+        .size()
+        .reset_index(name="count")
+    )


### PR DESCRIPTION
## Summary
- Add analytical helpers for per-section sentiment and label counts
- Introduce tabbed interface with overview, section, and headline analytics
- Highlight top positive and negative headlines and per-section metrics

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b77ebb6408832396cb3c295c44089f